### PR TITLE
update composer with new hamcrest package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,20 +5,6 @@
     "homepage": "https://github.com/Magomogo/persisted-models",
     "repositories": [
         {
-            "type": "package",
-            "package": {
-                "name": "hamcrest/hamcrest",
-                "version": "1.1.0",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://hamcrest.googlecode.com/files/hamcrest-php-1.1.0.zip"
-                },
-                "include-path": ["Hamcrest-1.1.0/"],
-                "autoload": {
-                    "psr-0": { "Hamcrest_": "Hamcrest-1.1.0/" },
-                    "files": ["Hamcrest-1.1.0/Hamcrest/Hamcrest.php"]
-                }
-            }
         }
     ],
     "require": {
@@ -32,7 +18,7 @@
         "ext-pdo_sqlite": "*",
         "mockery/mockery": "0.7.2",
         "phpunit/phpunit": "3.7.*",
-        "hamcrest/hamcrest": "1.1.0",
+        "hamcrest/hamcrest-php": "1.1.1",
         "doctrine/couchdb": "@dev"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
     "description": "A way to make domain-specific models persistent",
     "homepage": "https://github.com/Magomogo/persisted-models",
     "repositories": [
-        {
-        }
     ],
     "require": {
         "php":">=5.3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,27 @@
     "description": "A way to make domain-specific models persistent",
     "homepage": "https://github.com/Magomogo/persisted-models",
     "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "hamcrest/hamcrest",
+                "version": "1.1.0",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/n3phos/hamcrest/raw/master/hamcrest_1.1.0.zip"
+                },
+                "include-path": ["Hamcrest-1.1.0/"],
+                "autoload": {
+                    "psr-0": { "Hamcrest_": "Hamcrest-1.1.0/" },
+                    "files": ["Hamcrest-1.1.0/Hamcrest/Hamcrest.php"]
+                }
+            }
+        }
     ],
     "require": {
         "php":">=5.3.0",
         "doctrine/dbal": "2.3.0"
+
     },
     "require-dev": {
         "ext-pdo": "*",
@@ -16,7 +33,7 @@
         "ext-pdo_sqlite": "*",
         "mockery/mockery": "0.7.2",
         "phpunit/phpunit": "3.7.*",
-        "hamcrest/hamcrest-php": "1.1.1",
+        "hamcrest/hamcrest": "1.1.0",
         "doctrine/couchdb": "@dev"
     },
     "authors": [

--- a/test/Persisted/Container/SqlDbTest.php
+++ b/test/Persisted/Container/SqlDbTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Magomogo\Persisted\Container;
 
+require_once './vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php';
+
+
 use Mockery as m;
 use Magomogo\Persisted\Test\DbNames;
 use Magomogo\Persisted\Test\ObjectMother\Person as TestPerson;

--- a/test/Persisted/Container/SqlDbTest.php
+++ b/test/Persisted/Container/SqlDbTest.php
@@ -9,7 +9,7 @@ use Magomogo\Persisted\Test\DbNames;
 use Magomogo\Persisted\Test\ObjectMother\Person as TestPerson;
 use Magomogo\Persisted\AbstractProperties;
 use Magomogo\Persisted\Test\Person;
-use Hamcrest\Matchers;
+
 
 class SqlDbTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,10 +21,11 @@ class SqlDbTest extends \PHPUnit_Framework_TestCase
     public function testFollowsTableNamingConvention()
     {
         $db = self::dbMock();
-        $db->shouldReceive('insert')->with('person', Matchers::typeOf('array'))->once();
-        $db->shouldReceive('insert')->with('creditcard', Matchers::typeOf('array'))->once();
+        $db->shouldReceive('insert')->with('person', typeOf('array'))->once();
+        $db->shouldReceive('insert')->with('creditcard', typeOf('array'))->once();
         $properties = new Person\Properties;
         $properties->putIn(self::container($db));
+
     }
 
     public function testLoadsReferencesAccordingToReferenceName()

--- a/test/Persisted/Container/SqlDbTest.php
+++ b/test/Persisted/Container/SqlDbTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Magomogo\Persisted\Container;
 
-require_once './vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php';
+
 
 
 use Mockery as m;
@@ -9,6 +9,7 @@ use Magomogo\Persisted\Test\DbNames;
 use Magomogo\Persisted\Test\ObjectMother\Person as TestPerson;
 use Magomogo\Persisted\AbstractProperties;
 use Magomogo\Persisted\Test\Person;
+use Hamcrest\Matchers;
 
 class SqlDbTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,8 +21,8 @@ class SqlDbTest extends \PHPUnit_Framework_TestCase
     public function testFollowsTableNamingConvention()
     {
         $db = self::dbMock();
-        $db->shouldReceive('insert')->with('person', typeOf('array'))->once();
-        $db->shouldReceive('insert')->with('creditcard', typeOf('array'))->once();
+        $db->shouldReceive('insert')->with('person', Matchers::typeOf('array'))->once();
+        $db->shouldReceive('insert')->with('creditcard', Matchers::typeOf('array'))->once();
         $properties = new Person\Properties;
         $properties->putIn(self::container($db));
     }


### PR DESCRIPTION
Hello maxim

Persisted-models is a dependency in sts-shop backend composer.json. Please update composer to use the hamcrest-php instead of the google repo, because composer install on sts-shop backend fails otherwise.