### PR TITLE
Add properties PDO types

### DIFF
--- a/lib/Magomogo/Persisted/Container/SqlDb.php
+++ b/lib/Magomogo/Persisted/Container/SqlDb.php
@@ -141,15 +141,31 @@ class SqlDb implements ContainerInterface
     private function commit(array $row, $properties)
     {
         $tableName = $this->names->propertiesToName($properties);
-
+        $types = $this->propertiesPDOTypes($properties);
         if (!$properties->id($this)) {
-            $this->db->insert($this->db->quoteIdentifier($tableName), $row);
+            $this->db->insert($this->db->quoteIdentifier($tableName), $row, $types);
             $properties->persisted($this->defineNewId($properties, $tableName), $this);
         } else {
-            $this->db->update($this->db->quoteIdentifier($tableName), $row, array('id' => $properties->id($this)));
+            $this->db->update($this->db->quoteIdentifier($tableName), $row, array('id' => $properties->id($this)),
+                $types);
         }
 
         return $properties;
+    }
+
+    /**
+     * @param AbstractProperties $properties
+     * @return array|null
+     */
+    private function propertiesPDOTypes($properties)
+    {
+        $types = array();
+        foreach ($properties as $name => $property) {
+            if (is_bool($property)) {
+                $types[$name] = \PDO::PARAM_BOOL;
+            }
+        }
+        return $types;
     }
 
     /**

--- a/test/_classes/Magomogo/Persisted/Test/Affiliate/Cookie/Properties.php
+++ b/test/_classes/Magomogo/Persisted/Test/Affiliate/Cookie/Properties.php
@@ -13,6 +13,7 @@ class Properties extends AbstractProperties
 {
     public $id;
     public $lifeTime = 0;
+    public $isMaster = false;
 
     public function naturalKeyFieldName()
     {


### PR DESCRIPTION
Now all properties is casts to string by DBAL.
MariaDB with `STRICT_TRANS_TABLES` enabled in `sql_mode` throws `SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column…`  boolean `tinyint` field and `false` value which casts to blank string.
